### PR TITLE
Add CAPE/shear, spatial, and diurnal distribution plots

### DIFF
--- a/hwtmode/interpretation.py
+++ b/hwtmode/interpretation.py
@@ -129,24 +129,24 @@ def plot_top_activations(out_path, model_name, x_data, meta_df, neuron_activatio
         plt.close()
     return
 
-def cape_shear_modes(data_path, neuron_activations, mode='train', model_name='mod', number_neurons=4, num_storms=50, use_mask=False):
-        """
-        Match specified number of top storms of each neuron, fetch storm patch, and then plot bivariate density of each nueron in CAPE/Shear space. 
+def cape_shear_modes(data_path, output_path, neuron_activations, model_name, mode='train', num_storms=50, use_mask=False):
+    """
+    Match specified number of top storms of each neuron, fetch storm patch, and then plot bivariate density of each nueron in CAPE/Shear space. 
 
-        Args:
-            data_path: Absolute path of netcdf patch data
-            nueron_activations: CSV file of neuron activations 
-            mode: data partition: 'train', 'val', or 'test'
-            model_name: name of model used for training
-            number_neurons: number of nuerons in activation file
-            num_storms: number of top activated storms to use for density estimation for each neuron
+    Args:
+        data_path: Absolute path of netcdf patch data
+        output_path: Path to save output
+        nueron_activations: CSV file of neuron activations 
+        mode: data partition: 'train', 'val', or 'test'
+        model_name: name of model used for training
+        num_storms: number of top activated storms to use for density estimation for each neuron
 
-        Returns:
-            df: pandas dataframe of top storm values for CAPE and Shear, split by neuron
-            : bivariate density estimation plot
-        """
+    Returns:
+        : bivariate density estimation plot
+    """
     df = pd.DataFrame(columns=['CAPE', '6km Shear', 'Neuron'])
-    for n in list(neuron_activations.columns[-number_neurons:]):
+    cols = list(neuron_activations.columns[neuron_activations.columns.str.contains('neuron')])
+    for n in cols:
         var = ['MLCAPE_prev', 'USHR6_prev', 'VSHR6_prev']
         sub = neuron_activations.sort_values(by=[n], ascending=False).iloc[:num_storms, :].reset_index(drop=True)
         dates = sub['run_date']
@@ -163,6 +163,9 @@ def cape_shear_modes(data_path, neuron_activations, mode='train', model_name='mo
         df[['CAPE','6km Shear']] = df[['CAPE','6km Shear']].astype('float32')
         
     plt.figure(figsize=(20,16))
-    sns.kdeplot(data=df, x='CAPE', y='6km Shear', hue='Neuron', fill=True, alpha=0.5, thresh=0.4)
-        
-    return df 
+    sns.set(font_scale=2)
+    sns.kdeplot(data=df, x='CAPE', y='6km Shear', hue='Neuron', fill=True, alpha=0.5, clip=(0,8000))
+    plt.title(f'Storm Activations for Top {num_storms} Storms')
+    plt.savefig(f'{output_path}/CAPE_Shear.png', bbox_inches='tight')
+           
+    return

--- a/hwtmode/interpretation.py
+++ b/hwtmode/interpretation.py
@@ -1,5 +1,7 @@
 import numpy as np
 from sklearn.metrics import roc_auc_score
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from os.path import join
 from scipy.ndimage import gaussian_filter
@@ -148,7 +150,7 @@ def cape_shear_modes(neuron_activations, output_path, data_path, model_name, mod
     for n in cols:
         var = ['MLCAPE_prev', 'USHR6_prev', 'VSHR6_prev']
         sub = neuron_activations.sort_values(by=[n], ascending=False).iloc[:num_storms, :].reset_index(drop=True)
-        dates = sub['run_date']
+        dates = sub['run_date'].astype('datetime64[ns]')
         file_strings = [f'{data_path}NCARSTORM_{x.strftime("%Y%m%d")}-0000_d01_model_patches.nc' for x in dates]
         df_vals = []
 
@@ -224,6 +226,7 @@ def diurnal_neuron_activations(neuron_activations, output_path, model_name, mode
     fig, ax = plt.subplots(figsize=(20, 8))
 
     df = neuron_activations.copy()
+    df.time = df.time.astype('datetime64[ns]').reset_index(drop=True) - pd.Timedelta(6, 'H')
     neurons = list(neuron_activations.columns[neuron_activations.columns.str.contains('neuron')])
     colors = ['r', 'g', 'b', 'k', 'y', 'orange', 'purple', 'brown', 'w']
     for i, neuron in enumerate(neurons):

--- a/hwtmode/interpretation.py
+++ b/hwtmode/interpretation.py
@@ -129,7 +129,7 @@ def plot_top_activations(out_path, model_name, x_data, meta_df, neuron_activatio
         plt.close()
     return
 
-def cape_shear_modes(data_path, output_path, neuron_activations, mode, model_name, num_storms=50):
+def cape_shear_modes(neuron_activations, output_path, data_path, model_name, mode, num_storms=50):
     """
     Match specified number of top storms of each neuron, fetch storm patch,
     and then plot bivariate density of each nueron in CAPE/Shear space.

--- a/train_mode_cnn.py
+++ b/train_mode_cnn.py
@@ -183,11 +183,11 @@ def main():
                     neuron_activations[model_name][mode] = pd.read_csv(join(config["out_path"],
                                             f"neuron_activations_{model_name}_{mode}.csv"),
                                             index_col="index")
-                    cape_shear_modes(neuron_activations[model_name][mode], config["output_path"], config["data_path"],
+                    cape_shear_modes(neuron_activations[model_name][mode], config["out_path"], config["data_path"],
                                      model_name, mode, num_storms=50)
-                    spatial_neuron_activations(neuron_activations[model_name][mode], config["output_path"], model_name,
+                    spatial_neuron_activations(neuron_activations[model_name][mode], config["out_path"], model_name,
                                                mode, quant_thresh=0.9)
-                    diurnal_neuron_activations(neuron_activations[model_name][mode], config["output_path"], model_name,
+                    diurnal_neuron_activations(neuron_activations[model_name][mode], config["out_path"], model_name,
                                                mode, quant_thresh=0.9)
     return
 

--- a/train_mode_cnn.py
+++ b/train_mode_cnn.py
@@ -180,14 +180,14 @@ def main():
             print("Additional Plotting...")
             for model_name in config["models"].keys():
                 for mode in modes:
-                    neuron_activations[model_name][mode] = pd.read_csv(join(config["out_path"],
+                    neuron_activations = pd.read_csv(join(config["out_path"],
                                             f"neuron_activations_{model_name}_{mode}.csv"),
                                             index_col="index")
-                    cape_shear_modes(neuron_activations[model_name][mode], config["out_path"], config["data_path"],
+                    cape_shear_modes(neuron_activations, config["out_path"], config["data_path"],
                                      model_name, mode, num_storms=50)
-                    spatial_neuron_activations(neuron_activations[model_name][mode], config["out_path"], model_name,
+                    spatial_neuron_activations(neuron_activations, config["out_path"], model_name,
                                                mode, quant_thresh=0.9)
-                    diurnal_neuron_activations(neuron_activations[model_name][mode], config["out_path"], model_name,
+                    diurnal_neuron_activations(neuron_activations, config["out_path"], model_name,
                                                mode, quant_thresh=0.9)
     return
 

--- a/train_mode_cnn.py
+++ b/train_mode_cnn.py
@@ -2,7 +2,7 @@ from hwtmode.data import load_patch_files, combine_patch_data, min_max_scale, st
 from hwtmode.models import BaseConvNet, load_conv_net
 from hwtmode.evaluation import classifier_metrics
 from hwtmode.interpretation import score_neurons, plot_neuron_composites, plot_saliency_composites, \
-    plot_top_activations, plot_additional_vars, cape_shear_modes, spatial_neuron_activations, \
+    plot_top_activations, cape_shear_modes, spatial_neuron_activations, \
     diurnal_neuron_activations
 import argparse
 import yaml


### PR DESCRIPTION
I have rescinded my previous pull request regarding CAPE/Shear plots of individual storms in favor of this PR which is a KDE plot in CAPE/Shear space. It also includes plot functions for spatial and diurnal distributions of neuron activations. I have included all 3 features under a separate argument flag as they as much easier to compute than those that require large saliency files, etc. 