### PR TITLE
Charlie dev - HWT 2021 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - conda config --set channel_priority strict
 
 install:
-  - conda create -n test --yes -c conda-forge python=$PYTHON_VERSION pip numpy scipy matplotlib pandas xarray pyyaml netcdf4 scikit-learn seaborn cartopy tqdm memory_profiler
+  - conda create -n test --yes -c conda-forge python=$PYTHON_VERSION pip numpy scipy matplotlib pandas xarray pyyaml netcdf4 scikit-learn seaborn cartopy tqdm memory_profiler scikit-image
   - source activate test
   - pip install tensorflow==$TENSORFLOW_VERSION
   - pip install tensorflow-probability

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - conda config --set channel_priority strict
 
 install:
-  - conda create -n test --yes -c conda-forge python=$PYTHON_VERSION pip numpy scipy matplotlib pandas xarray pyyaml netcdf4 scikit-learn seaborn cartopy tqdm memory_profiler scikit-image
+  - conda create -n test --yes -c conda-forge python=$PYTHON_VERSION pip numpy scipy matplotlib pandas xarray pyyaml netcdf4 scikit-learn seaborn cartopy tqdm memory_profiler scikit-image pyarrow
   - source activate test
   - pip install tensorflow==$TENSORFLOW_VERSION
   - pip install tensorflow-probability==0.12.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - conda create -n test --yes -c conda-forge python=$PYTHON_VERSION pip numpy scipy matplotlib pandas xarray pyyaml netcdf4 scikit-learn seaborn cartopy tqdm memory_profiler scikit-image
   - source activate test
   - pip install tensorflow==$TENSORFLOW_VERSION
-  - pip install tensorflow-probability
+  - pip install tensorflow-probability==0.12.2
   - pip install pytest
   - pip install .
 script:

--- a/casper_run_script.sh
+++ b/casper_run_script.sh
@@ -3,15 +3,15 @@
 #SBATCH --account=NAML0001
 #SBATCH --ntasks=4
 #SBATCH --cpus-per-task=1
-#SBATCH --time=1:00:00
+#SBATCH --time=00:30:00
 #SBATCH --partition=dav
-#SBATCH --mem=128G
-#SBATCH --output=run_mode_cnn.%j.out
+#SBATCH --mem=64G
+#SBATCH --output=run_mode_cnn.out
 #SBATCH --mail-type=ALL
-#SBATCH --mail-user=dgagne@ucar.edu
-#SBATCH --reservation=casper_8xV100
+#SBATCH --mail-user=cbecker@ucar.edu
 #SBATCH --gres=gpu:v100:1
 module load cuda/10.1
-export PATH="/glade/u/home/dgagne/miniconda3/envs/goes/bin:$PATH"
-export PROJ_LIB="/glade/u/home/dgagne/miniconda3/envs/goes/share/proj"
-python -u run_mode_cnn.py config/ws_mode_cnn_run_20200504_uh.yml 
+conda activate hwt
+#export PATH="/glade/u/home/dgagne/miniconda3/envs/goes/bin:$PATH"
+#export PROJ_LIB="/glade/u/home/dgagne/miniconda3/envs/goes/share/proj"
+python -u run_mode_cnn.py config/charlie_run.yml

--- a/casper_train_script.sh
+++ b/casper_train_script.sh
@@ -3,16 +3,13 @@
 #SBATCH --account=NAML0001
 #SBATCH --ntasks=16
 #SBATCH --cpus-per-task=1
-#SBATCH --time=24:00:00
+#SBATCH --time=06:00:00
 #SBATCH --partition=dav
 #SBATCH --gres=gpu:v100:1
 #SBATCH --mem=256G
-#SBATCH --output=train_mode_cnn.%j.out
+#SBATCH --output=train_mode_wwind.out
 #SBATCH --mail-type=ALL
-#SBATCH --mail-user=ggantos@ucar.edu
+#SBATCH --mail-user=cbecker@ucar.edu
 module load gnu/8.3.0 openmpi/3.1.4 python/3.7.5 cuda/10.1
-ncar_pylib ncar_20200417
-export PATH="/glade/work/ggantos/ncar_20200417/bin:$PATH"
-
-pip install /glade/work/ggantos/HWT_mode/.
-python -u train_mode_cnn.py config/ws_mode_cnn_train_201210_uh_masked.yml -t -i -p
+conda activate smode
+python -u train_mode_cnn.py config/refl_32_patch.yml -t -i

--- a/config/HRRR_AWS.config
+++ b/config/HRRR_AWS.config
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+import numpy as np
+import pandas as pd
+from hagelslag.processing.ObjectMatcher import shifted_centroid_distance
+from hagelslag.processing.ObjectMatcher import centroid_distance, time_distance
+
+scratch_path = "/glade/scratch/cbecker/NSC_objects/HRRR_AWS_test_May_2020/"
+date_index = pd.date_range(start='2020-05-01', end='2020-06-01', freq='1H', closed='left', tz='UTC').to_pydatetime()
+
+# Use pd.Timedelta to correspond with delay in data availability from hour that script is submitted
+#date_index = pd.DatetimeIndex([pd.Timestamp.utcnow().strftime("%Y-%m-%d-%H")]) - pd.Timedelta(hours=3)
+ensemble_members = ['oper']
+
+config = dict(dates=date_index,
+              start_hour=1,
+              end_hour=17,
+              watershed_variable="REFC-entire_atmosphere",
+              ensemble_name="HRRR-ZARR",
+              ensemble_members=ensemble_members,
+              model_path="hrrrzarr/sfc/",
+              segmentation_approach="hyst",
+              model_watershed_params=(35, 50),
+              size_filter=12,
+              gaussian_window=1,
+              mrms_path=None,
+              mrms_variable="MESH_Max_60min_00.50",
+              mrms_watershed_params=(13, 1, 125, 100, 100),
+              object_matcher_params=([shifted_centroid_distance], np.array([1.0]),
+                                     np.array([24000])),
+              track_matcher_params=([centroid_distance, time_distance],
+                                     np.array([80000, 2])),
+              storm_variables=["REFC-entire_atmosphere", "MXUPHL_1hr_max_fcst-5000_2000m_above_ground"],
+              potential_variables=[],
+              tendency_variables=[],
+              shape_variables=["area", "eccentricity", "major_axis_length", "minor_axis_length", "orientation"],
+              variable_statistics=["mean", "max", "min"],
+              csv_path=scratch_path + "track_data_hrrr_3km_csv_refl/",
+              geojson_path=scratch_path + "track_data_hrrr_3km_json_refl/",
+              nc_path=scratch_path + "track_data_hrrr_3km_nc_refl/",
+              patch_radius=48,
+              unique_matches=True,
+              closest_matches=True,
+              match_steps=True,
+              train=False,
+              single_step=True,
+              label_type="gamma",
+              model_map_file="/glade/scratch/cbecker/hagelslag/mapfiles/hrrr_map_2016.txt",
+              mask_file=None)

--- a/config/HRRR_hagelslag.config
+++ b/config/HRRR_hagelslag.config
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+import numpy as np
+import pandas as pd
+from hagelslag.processing.ObjectMatcher import shifted_centroid_distance
+from hagelslag.processing.ObjectMatcher import centroid_distance, time_distance
+
+scratch_path = "/glade/scratch/cbecker/NSC_objects/HRRR/"
+dates = pd.read_csv("/glade/scratch/cbecker/test_HRRR_data/dates.txt",
+                      header=None)[0].astype(str).str.pad(14, side="right",fillchar="0")
+date_index = pd.DatetimeIndex(dates)
+ensemble_members = ['']
+
+
+config = dict(dates=date_index.to_pydatetime(),
+              start_hour=1,
+              end_hour=17,
+              watershed_variable="refc",
+              ensemble_name="HRRRE",
+              ensemble_members=ensemble_members,
+              model_path="/glade/scratch/cbecker/test_HRRR_data/HRRR/",
+              segmentation_approach="hyst",
+              #model_watershed_params=(30, 1, 80, 300, 50),
+              model_watershed_params=(35, 50),
+              size_filter=12,
+              gaussian_window=1,
+              mrms_path=None,
+              mrms_variable="MESH_Max_60min_00.50",
+              mrms_watershed_params=(13, 1, 125, 100, 100),
+              object_matcher_params=([shifted_centroid_distance], np.array([1.0]),
+                                     np.array([24000])),
+              track_matcher_params=([centroid_distance, time_distance],
+                                     np.array([80000, 2])),
+              storm_variables=["refc"],
+              potential_variables=["refc"],
+              tendency_variables=[],
+              shape_variables=["area", "eccentricity", "major_axis_length", "minor_axis_length", "orientation"],
+              variable_statistics=["mean", "max", "min"],
+              csv_path=scratch_path + "track_data_hrrr_3km_csv_refl/",
+              geojson_path=scratch_path + "track_data_hrrr_3km_json_refl/",
+              nc_path=scratch_path + "track_data_hrrr_3km_nc_refl/",
+              patch_radius=48,
+              unique_matches=True,
+              closest_matches=True,
+              match_steps=True,
+              train=False,
+              single_step=True,
+              label_type="gamma",
+              model_map_file="/glade/u/home/sobash/hagelslag/mapfiles/hrrr_map_2016.txt",
+              mask_file=None)

--- a/config/HRRR_run_cnn_gmm.yml
+++ b/config/HRRR_run_cnn_gmm.yml
@@ -1,9 +1,10 @@
 data_path: "/glade/scratch/cbecker/HRRR_objects/HRRR_AWS_realtime_033120/track_data_hrrr_3km_nc_refl/"
 meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
                  "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
+agg_variables: ["MXUPHL_1hr_max_fcst-5000_2000m_above_ground_max"]
 run_start_date: "today"
 run_end_date: "today"
-run_freq: "daily"
+run_freq: "hourly"
 out_path: "/glade/scratch/cbecker/HWT_rt_mods/"
 activation_path: "/glade/scratch/cbecker/HWT_realtime_test/activations/"
 labels_path: "/glade/scratch/cbecker/HWT_realtime_test/labels/"

--- a/config/HRRR_run_cnn_gmm.yml
+++ b/config/HRRR_run_cnn_gmm.yml
@@ -9,6 +9,7 @@ run_freq: "hourly"
 out_path: "/glade/scratch/cbecker/HWT_rt_mods/"
 activation_path: "/glade/scratch/cbecker/HWT_realtime_test/activations/"
 labels_path: "/glade/scratch/cbecker/HWT_realtime_test/labels/"
+output_format: "parquet"
 models:
   semi_supervised:
     mod_0:

--- a/config/HRRR_run_cnn_gmm.yml
+++ b/config/HRRR_run_cnn_gmm.yml
@@ -1,14 +1,12 @@
 data_path: "/glade/scratch/cbecker/NSC_objects/HRRR_AWS_test_May_2020/track_data_hrrr_3km_nc_refl/"
 meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
                  "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
-run_start_date: "2020-05-22"
-run_end_date: "2020-05-23"
+run_start_date: "2020-05-10"
+run_end_date: "2020-05-12"
 date_format: "%Y%m%d%H"
-start_hour: 01
-end_hour: 18
 out_path: "/glade/scratch/cbecker/HWT_rt_mods/"
-activation_path: "/glade/scratch/cbecker/HWT_run_test_output_2/activations/"
-labels_path: "/glade/scratch/cbecker/HWT_run_test_output_2/labels_test_w_geom/"
+activation_path: "/glade/scratch/cbecker/HWT_run_test_output_May2020/activations/"
+labels_path: "/glade/scratch/cbecker/HWT_run_test_output_May2020/labels_test_w_geom/"
 models:
   semi_supervised:
     mod_0:

--- a/config/HRRR_run_cnn_gmm.yml
+++ b/config/HRRR_run_cnn_gmm.yml
@@ -1,24 +1,22 @@
 data_path: "/glade/scratch/cbecker/NSC_objects/HRRR_AWS_test_May_2020/track_data_hrrr_3km_nc_refl/"
-patch_radius: 32
-input_variables: ["REFC-entire_atmosphere_curr"]
-output_variables: ["MXUPHL_1hr_max_fcst-5000_2000m_above_ground_curr"]
 meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
                  "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
-run_start_date: "2020-05-01"
-run_end_date: "2020-05-04"
+run_start_date: "2020-05-22"
+run_end_date: "2020-05-23"
 date_format: "%Y%m%d%H"
 start_hour: 01
 end_hour: 18
-out_path: "/glade/scratch/cbecker/HWT_out/refl_uh_class_021321/"
+out_path: "/glade/scratch/cbecker/HWT_rt_mods/"
 activation_path: "/glade/scratch/cbecker/HWT_run_test_output_2/activations/"
-labels_path: "/glade/scratch/cbecker/HWT_run_test_output_2/labels/"
+labels_path: "/glade/scratch/cbecker/HWT_run_test_output_2/labels_test_w_geom/"
 models:
-  mod_0:
-    neuron_002:
-      cmap: "Blues"
-      vmin: 0.0
-      vmax: 1.6
-    neuron_004:
-      cmap: "Reds"
-      vmin: 0.0
-      vmax: 1.6
+  semi_supervised:
+    mod_0:
+      patch_radius: 32
+      input_variables: ["REFC-entire_atmosphere_curr"]
+      output_variables: ["MXUPHL_1hr_max_fcst-5000_2000m_above_ground_curr"]
+  supervised:
+    cnn_test_000:
+      patch_radius: 32
+      input_variables: ["REFC-entire_atmosphere_curr", "MXUPHL_1hr_max_fcst-5000_2000m_above_ground_curr"]
+      output_variables: ["MXUPHL_1hr_max_fcst-5000_2000m_above_ground_curr"]

--- a/config/HRRR_run_cnn_gmm.yml
+++ b/config/HRRR_run_cnn_gmm.yml
@@ -1,12 +1,11 @@
-data_path: "/glade/scratch/cbecker/NSC_objects/HRRR_AWS_test_May_2020/track_data_hrrr_3km_nc_refl/"
+data_path: "/glade/scratch/cbecker/HRRR_objects/HRRR_AWS_realtime_033120/track_data_hrrr_3km_nc_refl/"
 meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
                  "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
-run_start_date: "2020-05-10"
-run_end_date: "2020-05-12"
-date_format: "%Y%m%d%H"
+run_start_date: "today"
+run_end_date: "today"
 out_path: "/glade/scratch/cbecker/HWT_rt_mods/"
-activation_path: "/glade/scratch/cbecker/HWT_run_test_output_May2020/activations/"
-labels_path: "/glade/scratch/cbecker/HWT_run_test_output_May2020/labels_test_w_geom/"
+activation_path: "/glade/scratch/cbecker/HWT_realtime_test/activations/"
+labels_path: "/glade/scratch/cbecker/HWT_realtime_test/labels/"
 models:
   semi_supervised:
     mod_0:

--- a/config/HRRR_run_cnn_gmm.yml
+++ b/config/HRRR_run_cnn_gmm.yml
@@ -5,12 +5,20 @@ output_variables: ["MXUPHL_1hr_max_fcst-5000_2000m_above_ground_curr"]
 meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
                  "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
 run_start_date: "2020-05-01"
-run_end_date: "2020-06-01"
+run_end_date: "2020-05-04"
 date_format: "%Y%m%d%H"
 start_hour: 01
 end_hour: 18
 out_path: "/glade/scratch/cbecker/HWT_out/refl_uh_class_021321/"
-activation_path: "/glade/scratch/cbecker/HWT_run_test_output/activations/"
-labels_path: "/glade/scratch/cbecker/HWT_run_test_output/labels/"
+activation_path: "/glade/scratch/cbecker/HWT_run_test_output_2/activations/"
+labels_path: "/glade/scratch/cbecker/HWT_run_test_output_2/labels/"
 models:
   mod_0:
+    neuron_002:
+      cmap: "Blues"
+      vmin: 0.0
+      vmax: 1.6
+    neuron_004:
+      cmap: "Reds"
+      vmin: 0.0
+      vmax: 1.6

--- a/config/HRRR_run_cnn_gmm.yml
+++ b/config/HRRR_run_cnn_gmm.yml
@@ -1,4 +1,5 @@
 data_path: "/glade/scratch/cbecker/HRRR_objects/HRRR_AWS_realtime_033120/track_data_hrrr_3km_nc_refl/"
+csv_model_prefix: "track_step_HRRR-ZARR_oper_"
 meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
                  "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
 agg_variables: ["MXUPHL_1hr_max_fcst-5000_2000m_above_ground_max"]

--- a/config/HRRR_run_cnn_gmm.yml
+++ b/config/HRRR_run_cnn_gmm.yml
@@ -1,0 +1,16 @@
+data_path: "/glade/scratch/cbecker/NSC_objects/HRRR_AWS_test_May_2020/track_data_hrrr_3km_nc_refl/"
+patch_radius: 32
+input_variables: ["REFC-entire_atmosphere_curr"]
+output_variables: ["MXUPHL_1hr_max_fcst-5000_2000m_above_ground_curr"]
+meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
+                 "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
+run_start_date: "2020-05-01"
+run_end_date: "2020-06-01"
+date_format: "%Y%m%d%H"
+start_hour: 01
+end_hour: 18
+out_path: "/glade/scratch/cbecker/HWT_out/refl_uh_class_021321/"
+activation_path: "/glade/scratch/cbecker/HWT_run_test_output/activations/"
+labels_path: "/glade/scratch/cbecker/HWT_run_test_output/labels/"
+models:
+  mod_0:

--- a/config/HRRR_run_cnn_gmm.yml
+++ b/config/HRRR_run_cnn_gmm.yml
@@ -3,6 +3,7 @@ meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centr
                  "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
 run_start_date: "today"
 run_end_date: "today"
+run_freq: "daily"
 out_path: "/glade/scratch/cbecker/HWT_rt_mods/"
 activation_path: "/glade/scratch/cbecker/HWT_realtime_test/activations/"
 labels_path: "/glade/scratch/cbecker/HWT_realtime_test/labels/"

--- a/config/WRF_run_cnn_gmm.yml
+++ b/config/WRF_run_cnn_gmm.yml
@@ -1,4 +1,5 @@
 data_path: "/glade/scratch/cbecker/WRF_objects/WRF_test/track_data_wrf_3km_nc_refl/"
+csv_model_prefix: "track_step_NCARSTORM_d01_"
 meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
                  "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
 agg_variables: ["UP_HELI_MAX_max"]

--- a/config/WRF_run_cnn_gmm.yml
+++ b/config/WRF_run_cnn_gmm.yml
@@ -1,6 +1,7 @@
-data_path: "/glade/scratch/cbecker/WRF_objects/WRF_test_041421/track_data_wrf_3km_nc_refl/"
+data_path: "/glade/scratch/cbecker/WRF_objects/WRF_test/track_data_wrf_3km_nc_refl/"
 meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
                  "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
+agg_variables: ["UP_HELI_MAX_max"]
 run_start_date: "today"
 run_end_date: "today"
 run_freq: "daily"

--- a/config/WRF_run_cnn_gmm.yml
+++ b/config/WRF_run_cnn_gmm.yml
@@ -1,0 +1,20 @@
+data_path: "/glade/scratch/cbecker/WRF_objects/WRF_test_041421/track_data_wrf_3km_nc_refl/"
+meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
+                 "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
+run_start_date: "today"
+run_end_date: "today"
+run_freq: "daily"
+out_path: "/glade/scratch/cbecker/HWT_rt_mods/"
+activation_path: "/glade/scratch/cbecker/HWT_WRF_test_output/activations/"
+labels_path: "/glade/scratch/cbecker/HWT_WRF_test_output/labels/"
+models:
+  semi_supervised:
+    mod_0:
+      patch_radius: 32
+      input_variables: ["REFL_COM_curr"]
+      output_variables: ["UP_HELI_MAX_curr"]
+  supervised:
+    cnn_test_000:
+      patch_radius: 32
+      input_variables: ["REFL_COM_curr", "UP_HELI_MAX_curr"]
+      output_variables: ["UP_HELI_MAX_curr"]

--- a/config/WRF_run_cnn_gmm.yml
+++ b/config/WRF_run_cnn_gmm.yml
@@ -9,6 +9,7 @@ run_freq: "daily"
 out_path: "/glade/scratch/cbecker/HWT_rt_mods/"
 activation_path: "/glade/scratch/cbecker/HWT_WRF_test_output/activations/"
 labels_path: "/glade/scratch/cbecker/HWT_WRF_test_output/labels/"
+output_format: "parquet"
 models:
   semi_supervised:
     mod_0:

--- a/config/charlie_run.yml
+++ b/config/charlie_run.yml
@@ -1,0 +1,25 @@
+data_path: "/glade/scratch/dgagne/NSC_data/track_data_nsc_3km_REFL_COM_ws_nc/"
+patch_radius: 32
+input_variables: ["REFL_COM_curr"]
+output_variables: ["UP_HELI_MAX_future"]
+meta_variables: ["masks", "i", "j", "lon", "lat", "time", "centroid_lon", "centroid_lat",
+                 "centroid_i", "centroid_j", "track_id", "track_step", "run_date"]
+#run_start_date: "today"
+#run_end_date: "today"
+run_start_date: "2017-06-11"
+run_end_date: "2017-06-11"
+date_format: "%Y%m%d%H"
+start_hour: 01
+end_hour: 35
+out_path: "/glade/scratch/cbecker/HWT_out/refl_uh_class_021321/" # should match output path in CNN config
+activation_path: "/glade/scratch/cbecker/HWT_out/refl_uh_class_021321/new_activations/"
+models:
+  mod_0:
+    neuron_002:
+      cmap: "Blues"
+      vmin: 0.0
+      vmax: 1.6
+    neuron_004:
+      cmap: "Reds"
+      vmin: 0.0
+      vmax: 1.6

--- a/config/ncar_storm_data_3km_2020.config
+++ b/config/ncar_storm_data_3km_2020.config
@@ -8,12 +8,12 @@ import os, sys
 from datetime import datetime
 
 work_path = "/glade/work/dgagne/NSC_data/"
-scratch_path = "/glade/scratch/dgagne/NSC_data/"
+scratch_path = "/glade/scratch/cbecker/NSC_data_hyst/"
 dates = pd.read_csv("/glade/u/home/dgagne/hagelslag/config/ncar_storm_dates_3km_new.txt",
                       header=None)[0].astype(str).str.pad(14, side="right",fillchar="0")
 date_index = pd.DatetimeIndex(dates)
 ensemble_members = ["d01"]
-pressure_levels = ["850", "700", "500", "300"]
+pressure_levels = ["850", "700", "500"]
 pres_vars = ["GHT_PL", "T_PL", "TD_PL", "U_PL", "V_PL"]
 full_pres_vars = []
 for pres_var in pres_vars:
@@ -34,13 +34,13 @@ REFL_COM = {
         "params": (40, 1, 80, 300, 50), 
         "object_matcher_params":([shifted_centroid_distance],np.array([1.0]),np.array([24000]))
         }
-segmentation_approach = "ws" # "hyst", "ws", or "ew"
+segmentation_approach = "hyst" # "hyst", "ws", or "ew"
 REFL_COM["params"] = (35, 50)
 watershed_dict = REFL_COM
 watershed_variable = watershed_dict["name"]
 output_prefix = scratch_path + "track_data_nsc_3km_"+watershed_variable+"_"+segmentation_approach
 config = dict(dates=date_index.to_pydatetime(),
-              start_hour=1,
+              start_hour=12,
               end_hour=35, # Don't go above maximum lead time-1 (35) or diagnostics file for storm_variables won't be found 
               watershed_variable=watershed_variable,
               ensemble_name="NCARSTORM",
@@ -49,7 +49,7 @@ config = dict(dates=date_index.to_pydatetime(),
               segmentation_approach = segmentation_approach, 
               model_watershed_params=watershed_dict["params"], 
               size_filter=12,
-              gaussian_window=0,
+              gaussian_window=1,
               #mrms_path= work_path + "mrms_ncar/",
               mrms_path=None,
               mrms_variable="MESH_Max_60min_00.50",
@@ -62,9 +62,9 @@ config = dict(dates=date_index.to_pydatetime(),
                                "UP_HELI_MIN", "REFL_COM", "REFL_1KM_AGL", "REFD_MAX",
                                "PSFC", "T2", "Q2", "TD2", "U10", "V10"] + full_pres_vars,
                                #"UP_HELI_MIN", "HAIL_MAXK1", "HAIL_MAX2D", "HAILCAST_DIAM_MAX",
-              potential_variables=["SBLCL", "MLLCL", "SBCAPE", "MLCAPE", "MUCAPE", "SBCINH", "MLCINH",
-                                   "USHR1", "VSHR1", "USHR6", "VSHR6", "U_BUNK", "V_BUNK",
-                                   "SRH03", "SRH01", "PSFC", "T2", "Q2", "TD2", "U10", "V10"],
+              potential_variables=["MLLCL", "SBCAPE", "MLCAPE", "MUCAPE", "SBCINH", "MLCINH",
+                                   "USHR6", "VSHR6", "U_BUNK", "V_BUNK",
+                                   "SRH03", "SRH01", "PSFC", "T2", "Q2", "TD2", "U10", "V10", "REFL_COM"],
                                    #"PSFC", "T2", "Q2", "TD2", "U10", "V10"] + full_pres_vars,
               future_variables=["REFL_COM", "UP_HELI_MAX", "GRPL_MAX", "HAIL_MAXK1", "UP_HELI_MAX03"],
               tendency_variables=[],
@@ -73,9 +73,6 @@ config = dict(dates=date_index.to_pydatetime(),
               #                     "percentile_10", "percentile_25", "percentile_50", "percentile_75", "percentile_90"],
               variable_statistics=["mean", "max", "min"],
               csv_path     = output_prefix + "_csv/",
-              geojson_path = output_prefix + "_json/",
-              nc_path      = output_prefix + "_nc/",
-              patch_radius=40,
               unique_matches=True,
               closest_matches=True,
               match_steps=True,
@@ -83,4 +80,5 @@ config = dict(dates=date_index.to_pydatetime(),
               single_step=True,
               label_type="gamma",
               model_map_file="/glade/u/home/dgagne/hagelslag/mapfiles/ncar_storm_map_3km.txt",
-              mask_file="/glade/u/home/dgagne/hagelslag/mapfiles/ncar_storm_us_mask_3km.nc")
+              #mask_file="/glade/u/home/dgagne/hagelslag/mapfiles/ncar_storm_us_mask_3km.nc")
+              mask_file=None)

--- a/hwtmode/data.py
+++ b/hwtmode/data.py
@@ -109,6 +109,30 @@ def combine_patch_data(patch_data, variables):
     return combined.transpose("p", "row", "col", "var_name")
 
 
+def min_max_scale(patch_data, scale_values=None):
+    """
+    Rescale the each variable in the combined DataArray to range from 0 to 1.
+    Args:
+        patch_data: Input data arranged in (p, rol, col, var_name) dimensions
+        scale_values: pandas.DataFrame containing min and max values for each variable.
+    Returns:
+        transformed: patch_data rescaled from 0 to 1
+    """
+    fit = False
+    if scale_values is None:
+        scale_values = pd.DataFrame(0, index=patch_data["var_name"].values, columns=["min", "max"])
+        fit = True
+    transformed = patch_data.copy(deep=True)
+    for v, var_name in enumerate(patch_data["var_name"].values):
+        print(var_name)
+        if fit:
+            scale_values.loc[var_name, "min"] = patch_data[..., v].min().values[()]
+            scale_values.loc[var_name, "max"] = patch_data[..., v].max().values[()]
+        transformed[..., v] = (patch_data[..., v] - scale_values.loc[var_name, "min"]) \
+            / (scale_values.loc[var_name, "max"] - scale_values.loc[var_name, "min"])
+    return transformed, scale_values
+
+
 def min_max_inverse_scale(transformed_data, scale_values):
     """
     Inverse scale data that ranges from 0 to 1 to the original values.

--- a/hwtmode/data.py
+++ b/hwtmode/data.py
@@ -7,7 +7,7 @@ import pandas as pd
 from skimage import measure
 from shapely.geometry import Polygon
 
-def load_patch_files(start_date: str, end_date: str, patch_dir: str, input_variables: list,
+def load_patch_files(start_date: str, end_date: str, run_freq: str, patch_dir: str, input_variables: list,
                      output_variables: list, meta_variables: list,
                      patch_radius=None, mask=False) -> tuple:
     """
@@ -17,6 +17,7 @@ def load_patch_files(start_date: str, end_date: str, patch_dir: str, input_varia
     Args:
         start_date (str): Beginning of date range for file loading.
         end_date (str): End of data range for file loading.
+        run_freq (str): Frequency at which to grab files
         patch_dir (str): Path to directory containing patch netCDF files.
         input_variables (list): List of input variable names.
         output_variables (list): List of output variable names.
@@ -33,10 +34,15 @@ def load_patch_files(start_date: str, end_date: str, patch_dir: str, input_varia
     date_strings = patch_files.str.split("/").str[-1].str.split("_").str[1]
     patch_dates = pd.to_datetime(date_strings)
     if start_date == "today":
-        start_date_stamp = pd.Timestamp(pd.Timestamp(start_date, tz="UTC").strftime("%Y-%m-%d %H:00:00")
-                                        ) - pd.Timedelta(hours=3)
-        end_date_stamp = pd.Timestamp(pd.Timestamp(end_date, tz="UTC").strftime("%Y-%m-%d %H:00:00")
-                                      ) - pd.Timedelta(hours=3)
+        if run_freq == "hourly":
+            start_date_stamp = pd.Timestamp(pd.Timestamp(start_date, tz="UTC").strftime("%Y-%m-%d %H:00:00")
+                                            ) - pd.Timedelta(hours=3)
+            end_date_stamp = pd.Timestamp(pd.Timestamp(end_date, tz="UTC").strftime("%Y-%m-%d %H:00:00")
+                                          ) - pd.Timedelta(hours=3)
+        elif run_freq == 'daily':
+            start_date_stamp = pd.Timestamp(pd.Timestamp(start_date, tz="UTC").strftime("%Y-%m-%d 00:00:00"))
+            end_date_stamp = pd.Timestamp(pd.Timestamp(end_date, tz="UTC").strftime("%Y-%m-%d 00:00:00"))
+
     else:
         start_date_stamp = pd.Timestamp(pd.Timestamp(start_date, tz="UTC").strftime("%Y-%m-%d %H:00:00"))
         end_date_stamp = pd.Timestamp(pd.Timestamp(end_date, tz="UTC").strftime("%Y-%m-%d %H:00:00"))

--- a/hwtmode/data.py
+++ b/hwtmode/data.py
@@ -219,7 +219,7 @@ def predict_labels_cnn(input_data, meta_df, model):
     df['label'] = -9999
     df['label_int'] = preds.argmax(axis=1)
     df['label_prob'] = preds.max(axis=1)
-    for i, label in enumerate(['Supercell', 'QLCS', 'Disorganized']):
+    for i, label in enumerate(['QLCS', 'Supercell', 'Disorganized']):
         df[label] = 0
         df[f'{label}_prob'] = preds[:, i]
         df.loc[df['label_int'] == i, 'label'] = label

--- a/hwtmode/data.py
+++ b/hwtmode/data.py
@@ -32,8 +32,14 @@ def load_patch_files(start_date: str, end_date: str, patch_dir: str, input_varia
     patch_files = pd.Series(sorted(glob(join(patch_dir, "*.nc"))))
     date_strings = patch_files.str.split("/").str[-1].str.split("_").str[1]
     patch_dates = pd.to_datetime(date_strings)
-    start_date_stamp = pd.Timestamp(pd.Timestamp(start_date).strftime("%Y-%m-%d 00:00:00"))
-    end_date_stamp = pd.Timestamp(pd.Timestamp(end_date).strftime("%Y-%m-%d 00:00:00"))
+    if start_date == "today":
+        start_date_stamp = pd.Timestamp(pd.Timestamp(start_date, tz="UTC").strftime("%Y-%m-%d %H:00:00")
+                                        ) - pd.Timedelta(hours=3)
+        end_date_stamp = pd.Timestamp(pd.Timestamp(end_date, tz="UTC").strftime("%Y-%m-%d %H:00:00")
+                                      ) - pd.Timedelta(hours=3)
+    else:
+        start_date_stamp = pd.Timestamp(pd.Timestamp(start_date, tz="UTC").strftime("%Y-%m-%d %H:00:00"))
+        end_date_stamp = pd.Timestamp(pd.Timestamp(end_date, tz="UTC").strftime("%Y-%m-%d %H:00:00"))
     date_filter = (patch_dates >= start_date_stamp) & (patch_dates <= end_date_stamp)
     valid_patch_files = patch_files[date_filter]
     valid_patch_dates = patch_dates[date_filter]

--- a/hwtmode/data.py
+++ b/hwtmode/data.py
@@ -309,7 +309,7 @@ def get_contours(data):
             skips.append(i)
     print('Generating mask outlines...')
     x, y = get_xy_coords(storms)
-    lat, lon = get_xy_coords(storms_lcc)
+    lon, lat = get_xy_coords(storms_lcc)
 
     data = data.to_dataframe()
     data = data.reset_index(level=[0, 1, 2]).drop_duplicates(subset='p', keep='first')

--- a/hwtmode/data.py
+++ b/hwtmode/data.py
@@ -312,7 +312,7 @@ def get_contours(data):
     data["x"] = x
     data["y"] = y
 
-    return data
+    return data, skips
 
 
 

--- a/hwtmode/data.py
+++ b/hwtmode/data.py
@@ -290,7 +290,7 @@ def get_contours(data):
     storms_lcc = []
     skips = []
     for i, mask in enumerate(masks):
-        contours = measure.find_contours(mask)[0]
+        contours = measure.find_contours(mask, 0.01)[0]
         lons_m = []
         lats_m = []
         lats_list, lons_list = [], []

--- a/hwtmode/data.py
+++ b/hwtmode/data.py
@@ -181,6 +181,6 @@ def predict_labels(neuron_acts, neuron_columns, gmm_model, cluster_dict):
         neuron_acts[f'{key}_prob'] = neuron_acts[[f'cluster_{x}_prob' for x in cluster_dict[key]]].sum(axis=1)
         neuron_acts[key] = 0
         neuron_acts.loc[neuron_acts['label'].isin([key]), key] = 1
-        labels_w_meta = neuron_acts.loc[:, neuron_acts.columns != neuron_columns]
+        labels_w_meta = neuron_acts.loc[:, ~neuron_acts.columns.isin(neuron_columns)]
 
     return labels_w_meta

--- a/rt_submit_wrapper.sh
+++ b/rt_submit_wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -l
+
+module reset
+date
+qsubcasper /glade/scratch/cbecker/hagelslag/run_hwt_pbs.sh

--- a/run_HRRR_pbs.sh
+++ b/run_HRRR_pbs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -l
+#PBS -N mode_cnn
+#PBS -A NAML0001
+#PBS -l walltime=00:30:00
+#PBS -o hwt_realtime.out
+#PBS -e hwt_realtime.err
+#PBS -q casper
+#PBS -l select=1:ncpus=18:mem=64GB
+#PBS -m a
+#PBS -M cbecker@ucar.edu
+conda activate hagelslag
+python -u /glade/scratch/cbecker/hagelslag/bin/hsdata /glade/scratch/cbecker/hagelslag/config/HRRR_AWS_stream.config -p 12
+conda activate hwt
+python -u /glade/work/cbecker/HWT_mode/run_mode_cnn.py /glade/work/cbecker/HWT_mode/config/HRRR_run_cnn_gmm.yml

--- a/run_WRF_pbs.sh
+++ b/run_WRF_pbs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -l
+#PBS -N mode_cnn
+#PBS -A NAML0001
+#PBS -l walltime=00:30:00
+#PBS -o hwt_WRF.out
+#PBS -e hwt_WRF.err
+#PBS -q casper
+#PBS -l select=1:ncpus=18:mem=64GB
+#PBS -m a
+#PBS -M cbecker@ucar.edu
+conda activate hagelslag
+python -u /glade/scratch/cbecker/hagelslag/bin/hsdata /glade/scratch/cbecker/hagelslag/config/rt_WRF_2021.config -p 18
+conda activate hwt
+python -u /glade/work/cbecker/HWT_mode/run_mode_cnn.py /glade/work/cbecker/HWT_mode/config/WRF_run_cnn_gmm.yml

--- a/run_hsdata_casper.sh
+++ b/run_hsdata_casper.sh
@@ -1,14 +1,14 @@
 #!/bin/bash -l
 #SBATCH --job-name=hsdata_wrfrt
 #SBATCH --account=NAML0001
-#SBATCH --ntasks=20
+#SBATCH --ntasks=24
 #SBATCH --cpus-per-task=1
-#SBATCH --time=3:00:00
+#SBATCH --time=02:00:00
 #SBATCH --partition=dav
-#SBATCH --mem=384G
-#SBATCH --output=hsdata_wrfrt.%j.out
+#SBATCH --mem=128G
+#SBATCH --output=hsdata_wrfrt.out
 #SBATCH --mail-type=ALL
-#SBATCH --reservation=casper_8xV100
-#SBATCH --mail-user=dgagne@ucar.edu
-export PATH="/glade/u/home/dgagne/miniconda3/envs/goes/bin:$PATH"
-python -u /glade/u/home/dgagne/hagelslag/bin/hsdata /glade/u/home/dgagne/hagelslag/config/ncar_rt2020_data.config -p 20
+#SBATCH --mail-user=cbecker@ucar.edu
+#export PATH="/glade/u/home/dgagne/miniconda3/envs/goes/bin:$PATH"
+conda activate hagelslag
+python -u /glade/scratch/cbecker/hagelslag/bin/hsdata /glade/work/cbecker/HWT_mode/config/HRRR_hagelslag.config -p 24

--- a/run_mode_cnn.py
+++ b/run_mode_cnn.py
@@ -24,8 +24,8 @@ def main():
             makedirs(path)
     models, gmms, neuron_activations = {}, {}, {}
     if config['run_freq'] == 'hourly':
-        start_str = (pd.Timestamp(config["run_start_date"], tz="UTC") - pd.Timedelta(hours=3)).strftime("%Y%m%d_%H00")
-        end_str = (pd.Timestamp(config["run_end_date"], tz="UTC") - pd.Timedelta(hours=3)).strftime("%Y%m%d_%H00")
+        start_str = (pd.Timestamp(config["run_start_date"], tz="UTC") - pd.Timedelta(hours=3)).strftime("%Y%m%d-%H00")
+        end_str = (pd.Timestamp(config["run_end_date"], tz="UTC") - pd.Timedelta(hours=3)).strftime("%Y%m%d-%H00")
     elif config['run_freq'] == 'daily':
         start_str = (pd.Timestamp(config["run_start_date"], tz="UTC")).strftime("%Y%m%d-0000")
         end_str = (pd.Timestamp(config["run_end_date"], tz="UTC")).strftime("%Y%m%d-0000")

--- a/run_mode_cnn.py
+++ b/run_mode_cnn.py
@@ -83,7 +83,7 @@ def main():
                 labels = pd.merge(labels, geometry_df)
 
             agg_storm_data = pd.read_csv(join(config['data_path'].replace('nc', 'csv'),
-                                              f'track_step_NCARSTORM_d01_{start_str}.csv'))
+                                              f'{config["csv_model_prefix"]}{start_str}.csv'))
             labels['MAX_UPHL'] = pd.merge(labels, agg_storm_data.drop(skips), on=labels.index)[config["agg_variables"]]
             if start_str != end_str:
                 labels.to_pickle(join(config["labels_path"], f'{model_name}_labels_{start_str}_{end_str}.pkl'))

--- a/run_mode_cnn.py
+++ b/run_mode_cnn.py
@@ -4,9 +4,10 @@ from os.path import exists, join
 from os import makedirs
 import pandas as pd
 import numpy as np
+import joblib
 from hwtmode.data import load_patch_files, combine_patch_data, min_max_scale, storm_max_value, get_meta_scalars
 from hwtmode.models import load_conv_net
-from hwtmode.analysis import plot_storm_mode_analysis_map
+#from hwtmode.analysis import plot_storm_mode_analysis_map
 
 def main():
     parser = argparse.ArgumentParser()
@@ -28,6 +29,7 @@ def main():
     print(list(meta.variables.keys()))
     meta_df = get_meta_scalars(meta)
     models = {}
+    gmms = {}
     neuron_activations = {}
     if not exists(config["activation_path"]):
         makedirs(config["activation_path"])
@@ -48,28 +50,38 @@ def main():
         print("Neuron activation shape:", neuron_activations[model_name].shape)
         run_dates = pd.DatetimeIndex(neuron_activations[model_name]["run_date"].unique())
         print(run_dates)
-        for run_date in run_dates:
-            print(run_date)
-            rdi = neuron_activations[model_name]["run_date"] == run_date
-            print("Run storm count", np.count_nonzero(rdi))
-            run_date_str = run_date.strftime(config["date_format"])
-            na_file = join(config["activation_path"],
-                           f"neuron_activations_{model_name}_{run_date_str}.csv")
-            neuron_activations[model_name].loc[rdi].to_csv(na_file, index_label="index")
-            meta_run = meta.isel(p=np.where(rdi)[0])
-            print(run_date.strftime("%Y-%m-%d") + " plot all storms")
-            plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
-                                         meta_run, config["models"][model_name],
-                                         run_date, 1, 35, model_name, config["activation_path"], period_total=True)
-            plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
-                                         meta_run, config["models"][model_name],
-                                         run_date, 12, 35, model_name, config["activation_path"], period_total=True)
-            print(run_date.strftime("%Y-%m-%d") + " plot hourly storms")
-            plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
-                                         meta_run, config["models"][model_name],
-                                         run_date, config["start_hour"], config["end_hour"], model_name,
-                                         config["activation_path"],
-                                         period_total=False)
+
+        gmms[model_name] = joblib.load(join(config["out_path"], f'{model_name}.gmm'))
+        gmms[model_name].predict(neuron_activations[model_name].loc[:, neuron_columns])
+        gmms[model_name].predict_proba(neuron_activations[model_name].loc[:, neuron_columns]).max(axis=1)
+        labels = joblib.load(join(config["out_path"], f'{model_name}_gmm_labels.dict'))
+
+        # for run_date in run_dates:
+        #     print(run_date)
+        #     rdi = neuron_activations[model_name]["run_date"] == run_date
+        #     print("Run storm count", np.count_nonzero(rdi))
+        #     run_date_str = run_date.strftime(config["date_format"])
+        #     na_file = join(config["activation_path"],
+        #                    f"neuron_activations_{model_name}_{run_date_str}.csv")
+        #     neuron_activations[model_name].loc[rdi].to_csv(na_file, index_label="index")
+        #     meta_run = meta.isel(p=np.where(rdi)[0])
+        #     print(run_date.strftime("%Y-%m-%d") + " plot all storms")
+            # plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
+            #                              meta_run, config["models"][model_name],
+            #                              run_date, 1, 35, model_name, config["activation_path"], period_total=True)
+            # plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
+            #                              meta_run, config["models"][model_name],
+            #                              run_date, 12, 35, model_name, config["activation_path"], period_total=True)
+            # print(run_date.strftime("%Y-%m-%d") + " plot hourly storms")
+            # plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
+            #                              meta_run, config["models"][model_name],
+            #                              run_date, config["start_hour"], config["end_hour"], model_name,
+            #                              config["activation_path"],
+            #                              period_total=False)
+
+            ### LOAD GMM, make predictions, append predictions to CSV ###
+
+
     return
 
 

--- a/run_mode_cnn.py
+++ b/run_mode_cnn.py
@@ -5,8 +5,8 @@ from os import makedirs
 import pandas as pd
 import numpy as np
 import joblib
-from hwtmode.data import load_patch_files, combine_patch_data, min_max_scale, get_meta_scalars, predict_labels, \
-    get_contours
+from hwtmode.data import load_patch_files, combine_patch_data, min_max_scale, get_meta_scalars, predict_labels_gmm, \
+    predict_labels_cnn, get_contours
 from hwtmode.models import load_conv_net
 from hwtmode.analysis import plot_storm_mode_analysis_map
 
@@ -21,75 +21,59 @@ def main():
         raise FileNotFoundError(args.config + " not found.")
     with open(args.config, "r") as config_file:
         config = yaml.load(config_file, Loader=yaml.Loader)
-    input_data, output, meta = load_patch_files(config["run_start_date"],
-                                                config["run_end_date"],
-                                                config["data_path"],
-                                                config["input_variables"],
-                                                config["output_variables"],
-                                                config["meta_variables"],
-                                                config["patch_radius"])
-    input_combined = combine_patch_data(input_data, config["input_variables"])
-    print(list(meta.variables.keys()))
-    meta_df = get_meta_scalars(meta)
-    models, gmms, labels, neuron_activations = {}, {}, {}, {}
     for path in [config["activation_path"], config["labels_path"]]:
         if not exists(path):
             makedirs(path)
+    models, gmms, neuron_activations = {}, {}, {}
 
-    for model_name in config["models"]:
+    for model_type, model_dict in config["models"].items():
+        for model_name in model_dict.keys():
 
-        print(model_name)
-        scale_values = pd.read_csv(join(config["out_path"], model_name, f"scale_values_{model_name}.csv"),
-                                   index_col="variable")
-        input_scaled, scale_values = min_max_scale(input_combined, scale_values)
-        print("Input shape", input_scaled.shape)
-        model_out_path = join(config["out_path"], model_name)
-        models[model_name] = load_conv_net(model_out_path, model_name)
-        print(models[model_name].model_.summary())
-        neuron_columns = [f"neuron_{n:03d}" for n in range(models[model_name].dense_neurons)]
-        neuron_activations[model_name] = pd.merge(meta_df, pd.DataFrame(0, columns=neuron_columns, index=meta_df.index),
-                                                  left_index=True, right_index=True)
-        neuron_activations[model_name].loc[:, neuron_columns] = \
-            models[model_name].output_hidden_layer(input_scaled.values)
-        print("Neuron activation shape:", neuron_activations[model_name].shape)
-        neuron_activations[model_name].to_csv(join(config["activation_path"], f'{model_name}_activations.csv'),
-                                              index=False)
+            print(model_name, f'({model_type})')
+            scale_values = pd.read_csv(join(config["out_path"], model_name, f"scale_values_{model_name}.csv"),
+                                       index_col="variable")
+            input_data, output, meta = load_patch_files(config["run_start_date"],
+                                                        config["run_end_date"],
+                                                        config["data_path"],
+                                                        model_dict[model_name]["input_variables"],
+                                                        model_dict[model_name]["output_variables"],
+                                                        config["meta_variables"],
+                                                        model_dict[model_name]["patch_radius"])
+            input_combined = combine_patch_data(input_data, model_dict[model_name]["input_variables"])
+            input_scaled, scale_values = min_max_scale(input_combined, scale_values)
+            meta_df = get_meta_scalars(meta)
+            geometry_df = get_contours(meta)
 
-        gmms[model_name] = joblib.load(join(config["out_path"], f'{model_name}.gmm'))
-        cluster_assignments = joblib.load(join(config["out_path"], f'{model_name}_gmm_labels.dict'))
-        labels[model_name] = predict_labels(neuron_activations[model_name], neuron_columns, gmms[model_name],
-                                            cluster_assignments)
-        geometry_df = get_contours(meta)
-        labels[model_name] = pd.merge(labels[model_name], geometry_df)
-        labels[model_name].insert(1, 'forecast_hour', ((labels[model_name]['time'] - labels[model_name]['run_date']) /
-                                                       pd.Timedelta(hours=1)).astype('int32'))
-        labels[model_name].to_pickle(join(config["labels_path"], f'{model_name}_predictions.pkl'))
+            print("Input shape", input_scaled.shape)
 
-        if args.plot_activation:
-            run_dates = pd.DatetimeIndex(neuron_activations[model_name]["run_date"].unique())
-            for run_date in run_dates:
-                print(run_date)
-                rdi = neuron_activations[model_name]["run_date"] == run_date
-                print("Run storm count", np.count_nonzero(rdi))
-                run_date_str = run_date.strftime(config["date_format"])
-                na_file = join(config["activation_path"],
-                               f"neuron_activations_{model_name}_{run_date_str}.csv")
-                neuron_activations[model_name].loc[rdi].to_csv(na_file, index_label="index")
-                meta_run = meta.isel(p=np.where(rdi)[0])
-                print(run_date.strftime("%Y-%m-%d") + " plot all storms")
-                plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
-                                             meta_run, config["models"][model_name],
-                                             run_date, 1, 18, model_name, config["activation_path"], period_total=True)
-                plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
-                                             meta_run, config["models"][model_name],
-                                             run_date, 12, 35, model_name, config["activation_path"], period_total=True)
-                print(run_date.strftime("%Y-%m-%d") + " plot hourly storms")
-                plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
-                                             meta_run, config["models"][model_name],
-                                             run_date, config["start_hour"], config["end_hour"], model_name,
-                                             config["activation_path"],
-                                             period_total=False)
-        print("Completed.")
+            model_out_path = join(config["out_path"], model_name)
+            models[model_name] = load_conv_net(model_out_path, model_name)
+            print(models[model_name].model_.summary())
+
+            if model_type == 'semi_supervised':
+
+                neuron_columns = [f"neuron_{n:03d}" for n in range(models[model_name].dense_neurons)]
+                neuron_activations[model_name] = pd.merge(meta_df, pd.DataFrame(0, columns=neuron_columns,
+                                                          index=meta_df.index), left_index=True, right_index=True)
+                neuron_activations[model_name].loc[:, neuron_columns] = \
+                    models[model_name].output_hidden_layer(input_scaled.values)
+                neuron_activations[model_name].to_csv(join(config["activation_path"], f'{model_name}_activations.csv'),
+                                                      index=False)
+
+                gmms[model_name] = joblib.load(join(config["out_path"], model_name, f'{model_name}.gmm'))
+                cluster_assignments = joblib.load(join(config["out_path"], model_name, f'{model_name}_gmm_labels.dict'))
+                labels = predict_labels_gmm(neuron_activations[model_name], neuron_columns, gmms[model_name],
+                                        cluster_assignments)
+                labels = pd.merge(labels, geometry_df)
+                labels.insert(1, 'forecast_hour', ((labels['time'] - labels['run_date']) /
+                                                    pd.Timedelta(hours=1)).astype('int32'))
+            elif model_type == 'supervised':
+
+               labels = predict_labels_cnn(input_scaled, geometry_df, models[model_name])
+
+            labels.to_pickle(join(config["labels_path"], f'{model_name}_labels.pkl'))
+
+    print("Completed.")
 
     return
 

--- a/run_mode_cnn.py
+++ b/run_mode_cnn.py
@@ -3,13 +3,13 @@ import yaml
 from os.path import exists, join
 from os import makedirs
 import pandas as pd
-import numpy as np
 import joblib
-from hwtmode.data import load_patch_files, combine_patch_data, min_max_scale, storm_max_value, get_meta_scalars
+from hwtmode.data import load_patch_files, combine_patch_data, min_max_scale, get_meta_scalars, predict_labels
 from hwtmode.models import load_conv_net
-#from hwtmode.analysis import plot_storm_mode_analysis_map
+
 
 def main():
+
     parser = argparse.ArgumentParser()
     parser.add_argument("config", help="Name of the config file.")
     args = parser.parse_args()
@@ -18,69 +18,45 @@ def main():
     with open(args.config, "r") as config_file:
         config = yaml.load(config_file, Loader=yaml.Loader)
     input_data, output, meta = load_patch_files(config["run_start_date"],
-                                           config["run_end_date"],
-                                           config["data_path"],
-                                           config["input_variables"],
-                                           config["output_variables"],
-                                           config["meta_variables"],
-                                           config["patch_radius"])
+                                                config["run_end_date"],
+                                                config["data_path"],
+                                                config["input_variables"],
+                                                config["output_variables"],
+                                                config["meta_variables"],
+                                                config["patch_radius"])
     input_combined = combine_patch_data(input_data, config["input_variables"])
-    out_max = storm_max_value(output[config["output_variables"][0]], meta["masks"])
     print(list(meta.variables.keys()))
     meta_df = get_meta_scalars(meta)
-    models = {}
-    gmms = {}
-    neuron_activations = {}
+    models, gmms, labels, neuron_activations = {}, {}, {}, {}
     if not exists(config["activation_path"]):
         makedirs(config["activation_path"])
     for model_name in config["models"]:
-        print(model_name)
-        scale_values = pd.read_csv(join(config["out_path"], model_name, f"scale_values_{model_name}.csv"), index_col="variable")
 
+        print(model_name)
+        scale_values = pd.read_csv(join(config["out_path"], model_name, f"scale_values_{model_name}.csv"),
+                                   index_col="variable")
         input_scaled, scale_values = min_max_scale(input_combined, scale_values)
         print("Input shape", input_scaled.shape)
         model_out_path = join(config["out_path"], model_name)
         models[model_name] = load_conv_net(model_out_path, model_name)
         print(models[model_name].model_.summary())
         neuron_columns = [f"neuron_{n:03d}" for n in range(models[model_name].dense_neurons)]
-        neuron_activations[model_name] = pd.merge(meta_df, pd.DataFrame(0, columns=neuron_columns,
-                                                                          index=meta_df.index),
-                                                    left_index=True, right_index=True)
-        neuron_activations[model_name].loc[:, neuron_columns] = models[model_name].output_hidden_layer(input_scaled.values)
+        neuron_activations[model_name] = pd.merge(meta_df, pd.DataFrame(0, columns=neuron_columns, index=meta_df.index),
+                                                  left_index=True, right_index=True)
+        neuron_activations[model_name].loc[:, neuron_columns] = \
+            models[model_name].output_hidden_layer(input_scaled.values)
         print("Neuron activation shape:", neuron_activations[model_name].shape)
-        run_dates = pd.DatetimeIndex(neuron_activations[model_name]["run_date"].unique())
-        print(run_dates)
+        neuron_activations[model_name].to_csv(join(config["activation_path"], f'{model_name}_activations.csv'),
+                                              index=False)
+        # run_dates = pd.DatetimeIndex(neuron_activations[model_name]["run_date"].unique())
+        # print(run_dates)
 
         gmms[model_name] = joblib.load(join(config["out_path"], f'{model_name}.gmm'))
-        gmms[model_name].predict(neuron_activations[model_name].loc[:, neuron_columns])
-        gmms[model_name].predict_proba(neuron_activations[model_name].loc[:, neuron_columns]).max(axis=1)
-        labels = joblib.load(join(config["out_path"], f'{model_name}_gmm_labels.dict'))
-
-        # for run_date in run_dates:
-        #     print(run_date)
-        #     rdi = neuron_activations[model_name]["run_date"] == run_date
-        #     print("Run storm count", np.count_nonzero(rdi))
-        #     run_date_str = run_date.strftime(config["date_format"])
-        #     na_file = join(config["activation_path"],
-        #                    f"neuron_activations_{model_name}_{run_date_str}.csv")
-        #     neuron_activations[model_name].loc[rdi].to_csv(na_file, index_label="index")
-        #     meta_run = meta.isel(p=np.where(rdi)[0])
-        #     print(run_date.strftime("%Y-%m-%d") + " plot all storms")
-            # plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
-            #                              meta_run, config["models"][model_name],
-            #                              run_date, 1, 35, model_name, config["activation_path"], period_total=True)
-            # plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
-            #                              meta_run, config["models"][model_name],
-            #                              run_date, 12, 35, model_name, config["activation_path"], period_total=True)
-            # print(run_date.strftime("%Y-%m-%d") + " plot hourly storms")
-            # plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
-            #                              meta_run, config["models"][model_name],
-            #                              run_date, config["start_hour"], config["end_hour"], model_name,
-            #                              config["activation_path"],
-            #                              period_total=False)
-
-            ### LOAD GMM, make predictions, append predictions to CSV ###
-
+        cluster_assignments = joblib.load(join(config["out_path"], f'{model_name}_gmm_labels.dict'))
+        labels[model_name] = predict_labels(neuron_activations[model_name], neuron_columns, gmms[model_name],
+                                            cluster_assignments)
+        labels[model_name].to_csv(join(config["labels_path"], f'{model_name}_predictions.csv'), index=False)
+        print("Completed.")
 
     return
 

--- a/run_mode_cnn.py
+++ b/run_mode_cnn.py
@@ -25,7 +25,7 @@ def main():
     models, gmms, neuron_activations = {}, {}, {}
     if config['run_freq'] == 'hourly':
         start_str = (pd.Timestamp(config["run_start_date"], tz="UTC") - pd.Timedelta(hours=3)).strftime("%Y%m%d_%H00")
-        end_str = (pd.Timestamp(config["run_end_date"], tz="UTC") - pd.Timedelta(hours=3)).strftime
+        end_str = (pd.Timestamp(config["run_end_date"], tz="UTC") - pd.Timedelta(hours=3)).strftime("%Y%m%d_%H00")
     elif config['run_freq'] == 'daily':
         start_str = (pd.Timestamp(config["run_start_date"], tz="UTC") - pd.Timedelta(hours=3)).strftime("%Y%m%d_0000")
         end_str = (pd.Timestamp(config["run_end_date"], tz="UTC") - pd.Timedelta(hours=3)).strftime("%Y%m%d_0000")

--- a/run_mode_cnn.py
+++ b/run_mode_cnn.py
@@ -69,7 +69,7 @@ def main():
                                                     pd.Timedelta(hours=1)).astype('int32'))
             elif model_type == 'supervised':
 
-               labels = predict_labels_cnn(input_scaled, geometry_df, models[model_name])
+                labels = predict_labels_cnn(input_scaled, geometry_df, models[model_name])
 
             labels.to_pickle(join(config["labels_path"], f'{model_name}_labels.pkl'))
 

--- a/run_mode_cnn.py
+++ b/run_mode_cnn.py
@@ -3,15 +3,18 @@ import yaml
 from os.path import exists, join
 from os import makedirs
 import pandas as pd
+import numpy as np
 import joblib
 from hwtmode.data import load_patch_files, combine_patch_data, min_max_scale, get_meta_scalars, predict_labels
 from hwtmode.models import load_conv_net
+from hwtmode.analysis import plot_storm_mode_analysis_map
 
 
 def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("config", help="Name of the config file.")
+    parser.add_argument("-p", "--plot_activation", action="store_true", help="Plot storms by specified active neurons.")
     args = parser.parse_args()
     if not exists(args.config):
         raise FileNotFoundError(args.config + " not found.")
@@ -28,8 +31,10 @@ def main():
     print(list(meta.variables.keys()))
     meta_df = get_meta_scalars(meta)
     models, gmms, labels, neuron_activations = {}, {}, {}, {}
-    if not exists(config["activation_path"]):
-        makedirs(config["activation_path"])
+    for path in [config["activation_path"], config["labels_path"]]:
+        if not exists(path):
+            makedirs(path)
+
     for model_name in config["models"]:
 
         print(model_name)
@@ -48,14 +53,37 @@ def main():
         print("Neuron activation shape:", neuron_activations[model_name].shape)
         neuron_activations[model_name].to_csv(join(config["activation_path"], f'{model_name}_activations.csv'),
                                               index=False)
-        # run_dates = pd.DatetimeIndex(neuron_activations[model_name]["run_date"].unique())
-        # print(run_dates)
 
         gmms[model_name] = joblib.load(join(config["out_path"], f'{model_name}.gmm'))
         cluster_assignments = joblib.load(join(config["out_path"], f'{model_name}_gmm_labels.dict'))
         labels[model_name] = predict_labels(neuron_activations[model_name], neuron_columns, gmms[model_name],
                                             cluster_assignments)
         labels[model_name].to_csv(join(config["labels_path"], f'{model_name}_predictions.csv'), index=False)
+
+        if args.plot_activation:
+            run_dates = pd.DatetimeIndex(neuron_activations[model_name]["run_date"].unique())
+            for run_date in run_dates:
+                print(run_date)
+                rdi = neuron_activations[model_name]["run_date"] == run_date
+                print("Run storm count", np.count_nonzero(rdi))
+                run_date_str = run_date.strftime(config["date_format"])
+                na_file = join(config["activation_path"],
+                               f"neuron_activations_{model_name}_{run_date_str}.csv")
+                neuron_activations[model_name].loc[rdi].to_csv(na_file, index_label="index")
+                meta_run = meta.isel(p=np.where(rdi)[0])
+                print(run_date.strftime("%Y-%m-%d") + " plot all storms")
+                plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
+                                             meta_run, config["models"][model_name],
+                                             run_date, 1, 18, model_name, config["activation_path"], period_total=True)
+                plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
+                                             meta_run, config["models"][model_name],
+                                             run_date, 12, 35, model_name, config["activation_path"], period_total=True)
+                print(run_date.strftime("%Y-%m-%d") + " plot hourly storms")
+                plot_storm_mode_analysis_map(neuron_activations[model_name].loc[rdi],
+                                             meta_run, config["models"][model_name],
+                                             run_date, config["start_hour"], config["end_hour"], model_name,
+                                             config["activation_path"],
+                                             period_total=False)
         print("Completed.")
 
     return

--- a/run_mode_cnn.py
+++ b/run_mode_cnn.py
@@ -86,11 +86,25 @@ def main():
                                               f'{config["csv_model_prefix"]}{start_str}.csv'))
             labels['MAX_UPHL'] = pd.merge(labels, agg_storm_data.drop(skips), on=labels.index)[config["agg_variables"]]
             if start_str != end_str:
-                labels.to_pickle(join(config["labels_path"], f'{model_name}_labels_{start_str}_{end_str}.pkl'))
-                print('Wrote', join(config["labels_path"], f'{model_name}_labels_{start_str}_{end_str}.pkl'))
+                if config['output_format'] == 'csv':
+                    labels.to_csv(join(config["labels_path"], f'{model_name}_labels_{start_str}_{end_str}.csv'),
+                                  index_label=False)
+                elif config['output_format'] == 'parquet':
+                    labels.to_parquet(join(config["labels_path"], f'{model_name}_labels_{start_str}_{end_str}.parquet'))
+                else:
+                    raise ValueError(f'File format {config["output_format"]} not found. Please use "parquet" or "csv"')
+                print('Wrote', join(config["labels_path"],
+                                    f'{model_name}_labels_{start_str}_{end_str}.{config["output_format"]}'))
             else:
-                labels.to_pickle(join(config["labels_path"], f'{model_name}_labels_{start_str}.pkl'))
-                print('Wrote', join(config["labels_path"], f'{model_name}_labels_{start_str}.pkl'))
+                if config['output_format'] == 'csv':
+                    labels.to_csv(join(config["labels_path"], f'{model_name}_labels_{start_str}.csv'),
+                                  index_label=False)
+                elif config['output_format'] == 'parquet':
+                    labels.to_parquet(join(config["labels_path"], f'{model_name}_labels_{start_str}.parquet'))
+                else:
+                    raise ValueError(f'File format {config["output_format"]} not found. Please use "parquet" or "csv"')
+                print('Wrote', join(config["labels_path"],
+                                    f'{model_name}_labels_{start_str}.{config["output_format"]}'))
 
     print("Completed.")
 

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -10,6 +10,7 @@ class TestData(unittest.TestCase):
             self.patch_path = "testdata/track_data_ncarstorm_3km_REFL_COM_ws_nc_small/"
         self.start_date = "2011-04-25"
         self.end_date = "2011-04-28"
+        self.run_freq = "daily"
         self.input_variables = ["REFL_1KM_AGL_curr", "U10_curr", "V10_curr"]
         self.output_variable = ["UP_HELI_MAX_curr"]
         self.meta_variables = ["masks", "i", "j", "time", "centroid_lon", "centroid_lat",
@@ -17,6 +18,7 @@ class TestData(unittest.TestCase):
         self.patch_radius = 16
         self.input_data, self.output_data, self.meta_data = load_patch_files(self.start_date,
                                                                              self.end_date,
+                                                                             self.run_freq,
                                                                              self.patch_path,
                                                                              self.input_variables,
                                                                              self.output_variable,

--- a/train_mode_cnn.py
+++ b/train_mode_cnn.py
@@ -125,24 +125,24 @@ def main():
                 neuron_activations[model_name][mode].to_csv(join(config["out_path"],
                                                      f"neuron_activations_{model_name}_{mode}.csv"),
                                                 index_label="index")
-                # saliency[model_name][mode] = models[model_name].saliency(input_scaled[mode])
-                #
-                # saliency[model_name][mode].to_netcdf(join(config["out_path"],
-                #                                           f"neuron_saliency_{model_name}_{mode}.nc"),
-                #                                      encoding={"saliency": {"zlib": True,
-                #                                                             "complevel": 4,
-                #                                                             "shuffle": True,
-                #                                                             "least_significant_digit": 3}})
-                #if config["classifier"]:
-                #    neuron_scores[model_name].loc[mode] = score_neurons(labels[mode],
-                #                                                        neuron_activations[model_name][mode][neuron_columns].values)
-                #else:
-                #    neuron_scores[model_name].loc[mode] = score_neurons(labels[mode],
-                #                                                        neuron_activations[model_name][mode][neuron_columns].values,
-                #                                        metric="r")
-                #del saliency[model_name][mode]
-            #neuron_scores[model_name].to_csv(join(config["out_path"],
-             #                                f"neuron_scores_{model_name}.csv"), index_label="mode")
+                saliency[model_name][mode] = models[model_name].saliency(input_scaled[mode])
+
+                saliency[model_name][mode].to_netcdf(join(config["out_path"],
+                                                          f"neuron_saliency_{model_name}_{mode}.nc"),
+                                                     encoding={"saliency": {"zlib": True,
+                                                                            "complevel": 4,
+                                                                            "shuffle": True,
+                                                                            "least_significant_digit": 3}})
+                if config["classifier"]:
+                   neuron_scores[model_name].loc[mode] = score_neurons(labels[mode],
+                                                                       neuron_activations[model_name][mode][neuron_columns].values)
+                else:
+                   neuron_scores[model_name].loc[mode] = score_neurons(labels[mode],
+                                                                       neuron_activations[model_name][mode][neuron_columns].values,
+                                                       metric="r")
+                del saliency[model_name][mode]
+            neuron_scores[model_name].to_csv(join(config["out_path"],
+                                            f"neuron_scores_{model_name}.csv"), index_label="mode")
             del models[model_name], neuron_activations[model_name]
     if args.plot:
         print("Begin plotting")

--- a/train_mode_cnn.py
+++ b/train_mode_cnn.py
@@ -101,6 +101,7 @@ def main():
                 predictions[mode].loc[:, model_name] = models[model_name].predict(input_scaled[mode].values)
         for mode in modes:
             predictions[mode].to_csv(join(config["out_path"], f"predictions_{mode}.csv"), index_label="index")
+        #del
         print("Calculate metrics")
         if config["classifier"]:
             model_scores = classifier_metrics(labels["test"], predictions["test"][list(config["models"].keys())])
@@ -123,25 +124,25 @@ def main():
                 neuron_activations[model_name][mode].to_csv(join(config["out_path"],
                                                      f"neuron_activations_{model_name}_{mode}.csv"),
                                                 index_label="index")
-                saliency[model_name][mode] = models[model_name].saliency(input_scaled[mode])
-
-                saliency[model_name][mode].to_netcdf(join(config["out_path"],
-                                                          f"neuron_saliency_{model_name}_{mode}.nc"),
-                                                     encoding={"saliency": {"zlib": True,
-                                                                            "complevel": 4,
-                                                                            "shuffle": True,
-                                                                            "least_significant_digit": 3}})
-                if config["classifier"]:
-                    neuron_scores[model_name].loc[mode] = score_neurons(labels[mode],
-                                                                        neuron_activations[model_name][mode][neuron_columns].values)
-                else:
-                    neuron_scores[model_name].loc[mode] = score_neurons(labels[mode],
-                                                                        neuron_activations[model_name][mode][neuron_columns].values,
-                                                        metric="r")
-                del saliency[model_name][mode]
-            neuron_scores[model_name].to_csv(join(config["out_path"],
-                                             f"neuron_scores_{model_name}.csv"), index_label="mode")
-            del models[model_name], neuron_scores[model_name]
+                # saliency[model_name][mode] = models[model_name].saliency(input_scaled[mode])
+                #
+                # saliency[model_name][mode].to_netcdf(join(config["out_path"],
+                #                                           f"neuron_saliency_{model_name}_{mode}.nc"),
+                #                                      encoding={"saliency": {"zlib": True,
+                #                                                             "complevel": 4,
+                #                                                             "shuffle": True,
+                #                                                             "least_significant_digit": 3}})
+                #if config["classifier"]:
+                #    neuron_scores[model_name].loc[mode] = score_neurons(labels[mode],
+                #                                                        neuron_activations[model_name][mode][neuron_columns].values)
+                #else:
+                #    neuron_scores[model_name].loc[mode] = score_neurons(labels[mode],
+                #                                                        neuron_activations[model_name][mode][neuron_columns].values,
+                #                                        metric="r")
+                #del saliency[model_name][mode]
+            #neuron_scores[model_name].to_csv(join(config["out_path"],
+             #                                f"neuron_scores_{model_name}.csv"), index_label="mode")
+            del models[model_name], neuron_activations[model_name]
     if args.plot:
         print("Begin plotting")
         if "plot_kwargs" not in config.keys():

--- a/train_mode_cnn.py
+++ b/train_mode_cnn.py
@@ -48,6 +48,7 @@ def main():
     for mode in modes:
         data_input[mode], output[mode], meta[mode] = load_patch_files(config[mode + "_start_date"],
                                                                  config[mode + "_end_date"],
+                                                                 run_freq=None,
                                                                  config["data_path"],
                                                                  config["input_variables"],
                                                                  config["output_variables"],

--- a/train_mode_cnn.py
+++ b/train_mode_cnn.py
@@ -48,7 +48,7 @@ def main():
     for mode in modes:
         data_input[mode], output[mode], meta[mode] = load_patch_files(config[mode + "_start_date"],
                                                                  config[mode + "_end_date"],
-                                                                 run_freq=None,
+                                                                 None,
                                                                  config["data_path"],
                                                                  config["input_variables"],
                                                                  config["output_variables"],


### PR DESCRIPTION
Summary of changes:

-  Major modifications to `run_mode_cnn.py` to accommodate real time runs for both CNN and GMM trained models
- Changes in both configs and run_script to work with either WRF or HRRR data at various run intervals
- Config support for an arbitrary number of models for both CNN and GMM
- Outputs pickle files of model classifications, probabilities, storm object geometry, and other storm statistics for each model
- Add pipeline scripts

Misc change:

- Added functions for predicting / evaluating across an entire grid rather than centered storm object. This currently doesn't support overlapping patches across the grid. See commit from 05/12/2021 

